### PR TITLE
d855: set /system mount as recoveryonly

### DIFF
--- a/rootdir/etc/fstab.g3
+++ b/rootdir/etc/fstab.g3
@@ -6,6 +6,7 @@
 # Currently we dont have e2fsck compiled. So fs check would failed.
 
 #<src>                                              <mnt_point>     <type>  <mnt_flags and options>                                             <fs_mgr_flags>
+/dev/block/platform/msm_sdcc.1/by-name/system       /system         ext4    ro,barrier=1,noatime                                                wait,recoveryonly
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                     wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/encrypt
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,noatime,noauto_da_alloc,errors=continue,journal_async_commit wait,check,formattable,encryptable=/dev/block/platform/msm_sdcc.1/by-name/encrypt
 /dev/block/platform/msm_sdcc.1/by-name/cache        /cache          f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr                     wait,check,formattable


### PR DESCRIPTION
 * Mounting /system partition is handled in kernel now, however
   removing the entry from fstab caused issues building the OTA. Simply
   setting the recoveryonly flag does the trick because those are then
   ignored during a normal Android boot.

Change-Id: I8e558458b984e97a45a920c3751a6b7c3f2ebc5c